### PR TITLE
Feature/docker ignore node modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ config.py
 *.py[cod]
 .idea
 
+/node_modules
+
 bin
 venv
 tmp

--- a/Dockerfile.gulp
+++ b/Dockerfile.gulp
@@ -20,9 +20,9 @@ ENV HOME /home/webdev
 
 RUN mkdir /app && chown webdev:webdev /app
 WORKDIR /app
-COPY --chown=webdev:webdev . /app
-
-RUN ln -s /app/node_modules/gulp/bin/gulp.js /usr/bin/gulp
-
 USER webdev
-RUN npm install
+
+COPY --chown=webdev:webdev ./assets ./assets
+COPY --chown=webdev:webdev ./package.json ./package-lock.json ./.babelrc ./babel.cfg ./gulpfile.babel.js ./
+
+RUN npm ci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     ports:
       - 5000:5000
     container_name: shared-delivery-flask
-    volumes:
-      - .:/app
     networks:
       shared-delivery:
         aliases:
@@ -20,8 +18,6 @@ services:
       context: .
       dockerfile: Dockerfile.flask
     container_name: shared-delivery-worker
-    volumes:
-      - .:/app
     networks:
       shared-delivery:
         aliases:
@@ -33,15 +29,11 @@ services:
       context: .
       dockerfile: Dockerfile.gulp
     container_name: shared-delivery-gulp
-    volumes:
-      - .:/app
-      - shared-delivery-node-modules:/app/node_modules
     networks:
       shared-delivery:
         aliases:
         - gulp
-    #entrypoint: ['sleep', '600000']
-    entrypoint: ["gulp", 'watch']
+    entrypoint: ["npm", "run", "gulp:watch"]
 
   mysql:
     image: mariadb
@@ -105,7 +97,6 @@ services:
         aliases:
         - rabbitmq
 volumes:
-  shared-delivery-node-modules:
   shared-delivery-mysql:
   shared-delivery-elastic:
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -10,14 +10,11 @@ import cache from 'gulp-cached';
 import remember from 'gulp-remember';
 import concat from 'gulp-concat';
 import gulpif from 'gulp-if';
-import source from 'vinyl-source-stream';
-import cssnanoe from 'gulp-cssnano';
 import gulpWebpack from 'webpack-stream';
 import webpack from 'webpack';
 import "@babel/polyfill";
 
 const basePaths = {
-    packages: './node_modules',
     dest: './static',
     src: './assets'
 };
@@ -43,11 +40,6 @@ const webpackConfigurationProduction = require('./assets/webpack.production.conf
 const webpackClientConfiguration = require('./assets/webpack.client.config.js');
 const webpackClientConfigurationProduction = require('./assets/webpack.client.production.config');
 
-
-let handleError = function (err) {
-    console.log(err.toString());
-    this.emit('end');
-};
 
 let enabled = {
     rev: 0

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "gulp:watch": "gulp watch"
   },
   "author": "binary butterfly GmbH",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "gulp:watch": "gulp watch"
   },
   "author": "binary butterfly GmbH",
   "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "gulp:watch": "gulp watch"
+    "gulp:watch": "gulp watch",
+    "gulp:deploy": "gulp deploy",
+    "gulp:webpack": "gulp webpack"
   },
   "author": "binary butterfly GmbH",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Mit dieser Änderung ist ein manuelles `npm install` im gulp Container nicht nicht mehr nötig.

Die `node_modules` werden nicht mehr in den Docker Build Context kopiert, so dass ein `npm ci` die `node-sass` korrekt für Linux installiert.

Bei mir klappt damit ein `docker-compose build && docker-compose up` ohne Fehler im gulp Container.